### PR TITLE
chore: bump versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
-    "@types/node": "^18.11.18",
-    "eslint": "^8.33.0",
-    "nuxt": "^3.2.3",
-    "typescript": "^4.9.5",
-    "vue-tsc": "^1.0.24"
+    "@types/node": "^18.16.5",
+    "eslint": "^8.40.0",
+    "nuxt": "^3.4.3",
+    "typescript": "^5.0.4",
+    "vue-tsc": "^1.6.4"
   }
 }


### PR DESCRIPTION
Contributes to update versions to the newest ones:

```
❯ npx taze major -w

› - 1 major, 4 minor

  typescript   dev  ~3mo     ^4.9.5  →    ^5.0.4  ~28d                    
  @types/node  dev  ~4mo  ^18.11.18  →  ^18.16.5   ⩽1d  (20.1.0 available)
  eslint       dev  ~3mo    ^8.33.0  →   ^8.40.0   ⩽1d                    
  nuxt         dev  ~2mo     ^3.2.3  →    ^3.4.3   ~7d                    
  vue-tsc      dev  ~4mo    ^1.0.24  →    ^1.6.4   ~2d                    
```

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
